### PR TITLE
Ability to disable default mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 dirvish-fs is a complimentary plugin to [vim-dirvish](https://github.com/justinmk/vim-dirvish). It has two features
 
 - Shortcuts to add/move/copy/remove nodes in dirvish buffers.
-- Shortcut to jump to the current directory and up a directory.
 
 ## Installation
 
@@ -22,11 +21,25 @@ Plug 'antonk52/dirvish-fs.vim'
 - <kbd>mm</kbd> - move node
 - <kbd>mc</kbd> - copy node
 - <kbd>dd</kbd> - remove node
-- <kbd>-</kbd> - go up a directory
 
-### In any buffer
+### Custom mappings
 
-- <kbd>-</kbd> - open current directory from a file buffer
+To disable the default mappings add the following to your `.vimrc`
+
+```viml
+" disables default mappings
+let g:dirvish_fs_default_mappings = 0
+
+" sets custom mappings
+function! DivrishMappings()
+    nmap <buffer> <silent>dd <Plug>DirvishFsRemove
+    nmap <buffer> <silent>ma <Plug>DirvishFsAdd
+    nmap <buffer> <silent>mm <Plug>DirvishFsMove
+    nmap <buffer> <silent>mc <Plug>DirvishFsCopy
+endfunction
+
+autocmd FileType dirvish call DivrishMappings()
+```
 
 ## Why?
 

--- a/autoload/dirvish_fs/fs.vim
+++ b/autoload/dirvish_fs/fs.vim
@@ -20,7 +20,7 @@ function! PrepareDestDirectory(path) abort
     let path_sep = '/'
     let list = split(a:path, path_sep)
     " viml cuts off the first slash
-    let dir_path = getcwd() . path_sep . join(list[:-2], path_sep)
+    let dir_path = path_sep . join(list[:-2], path_sep)
 
     if !isdirectory(dir_path)
         execute('silent !' . s:cmd.add_dir . ' ' . dir_path)

--- a/autoload/dirvish_fs/fs.vim
+++ b/autoload/dirvish_fs/fs.vim
@@ -16,13 +16,14 @@ let s:msg = {
 
 " if the destination is in non existing directory - create it
 function! PrepareDestDirectory(path) abort
+    " TODO: make this windows friendly
     let path_sep = '/'
     let list = split(a:path, path_sep)
     " viml cuts off the first slash
-    let dir_path = path_sep . join(list[:-2], path_sep)
+    let dir_path = getcwd() . path_sep . join(list[:-2], path_sep)
 
     if !isdirectory(dir_path)
-        execute('!' . s:cmd.add_dir . ' ' . dir_path)
+        execute('silent !' . s:cmd.add_dir . ' ' . dir_path)
     endif
 
     return 1
@@ -40,7 +41,7 @@ function! dirvish_fs#fs#add() abort
         redraw!
         echo s:msg.exists
     else
-        execute('!' . cmd . ' ' . substitute(new_path, '\/$', '', ''))
+        execute('silent !' . cmd . ' ' . substitute(new_path, '\/$', '', ''))
         redraw!
     endif
 endfunction
@@ -61,7 +62,7 @@ function! dirvish_fs#fs#remove() abort
     endif
 
     if confirmed
-        execute('!' . s:cmd.remove . ' ' . target)
+        execute('silent !' . s:cmd.remove . ' ' . target)
         " redraws the buffer and removes `Press ENTER or type command to continue`
         redraw!
     else
@@ -74,7 +75,7 @@ function! dirvish_fs#fs#move() abort
     let old_path = trim(getline('.'))
     let new_path = input(s:msg.add_node, old_path, 'file')
     call PrepareDestDirectory(new_path)
-    execute('!' . s:cmd.move . ' ' . old_path . ' ' . new_path)
+    execute('silent !' . s:cmd.move . ' ' . old_path . ' ' . new_path)
     redraw!
 endfunction
 
@@ -82,6 +83,6 @@ function! dirvish_fs#fs#copy() abort
     let old_path = trim(getline('.'))
     let new_path = input(s:msg.add_node, old_path, 'file')
     call PrepareDestDirectory(new_path)
-    execute('!' . s:cmd.copy . ' ' . old_path . ' ' . new_path)
+    execute('silent !' . s:cmd.copy . ' ' . old_path . ' ' . new_path)
     redraw!
 endfunction

--- a/autoload/dirvish_fs/mappings.vim
+++ b/autoload/dirvish_fs/mappings.vim
@@ -1,6 +1,6 @@
 function! dirvish_fs#mappings#set() abort
-    nnoremap <buffer> <silent>dd :call dirvish_fs#fs#remove()<cr>
-    nnoremap <buffer> <silent>ma :call dirvish_fs#fs#add()<cr>
-    nnoremap <buffer> <silent>mm :call dirvish_fs#fs#move()<cr>
-    nnoremap <buffer> <silent>mc :call dirvish_fs#fs#copy()<cr>
+    nmap <buffer> <silent>dd <Plug>DirvishFsRemove
+    nmap <buffer> <silent>ma <Plug>DirvishFsAdd
+    nmap <buffer> <silent>mm <Plug>DirvishFsMove
+    nmap <buffer> <silent>mc <Plug>DirvishFsCopy
 endfunction

--- a/plugin/dirvish_fs.vim
+++ b/plugin/dirvish_fs.vim
@@ -1,4 +1,11 @@
-autocmd FileType dirvish call dirvish_fs#mappings#set()
+nnoremap <silent> <Plug>DirvishFsRemove :call dirvish_fs#fs#remove()<cr>
+nnoremap <silent> <Plug>DirvishFsAdd :call dirvish_fs#fs#add()<cr>
+nnoremap <silent> <Plug>DirvishFsMove :call dirvish_fs#fs#move()<cr>
+nnoremap <silent> <Plug>DirvishFsCopy :call dirvish_fs#fs#copy()<cr>
 
-" vim-vinegar in a nutshell
-nnoremap <silent> - :call dirvish#open(expand('%:h'))<cr>
+let defaults_enabled = get(g:, 'dirvish_fs_default_mappings', 1)
+
+if defaults_enabled
+    autocmd FileType dirvish call dirvish_fs#mappings#set()
+endif
+


### PR DESCRIPTION
This PR has 3 changes
- ability to disable default mappings to set custom ones
- removes <kbd>-</kbd> shortcut since it comes with dirvish
- removes `Press ENTER to continue` from `PrepareDestDirectory` function

fixes #1 